### PR TITLE
Mkdir LaunchAgent dir if not existing on install for MacOs

### DIFF
--- a/aosvc-python/install_mac.sh
+++ b/aosvc-python/install_mac.sh
@@ -8,6 +8,7 @@ user_uid=$(id -u)
 
 mkdir -p "$service_path"
 cp aosvc "$service_path"
+mkdir -p "$launch_config_dir"
 cp aosvc.plist "$launch_config_path"
 launchctl bootstrap "gui/$user_uid" "$launch_config_path"
 launchctl start aosvc


### PR DESCRIPTION
If the directory doens't exists then create the LaunchAgent dir

Fixes https://github.com/ilyatbn/aws_alwayson/issues/11

# QA
- `cd aosvc-python`
- `rm -rf ~/Library/LaunchAgents/`
- `./uninstall_mac.sh`
- `./install_mac.sh`

Should work all good!